### PR TITLE
Ajustar permisos y mejoras para la copia de seguridad

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+ARG MARIADB_VERSION=10.4.22
+FROM mariadb:${MARIADB_VERSION}
+LABEL Maintainer="github.com/xaabi6"
+LABEL Description="MariaDB container with custom UID and GID for mysql user and group."
+
+# Custom UID and GID. Use the same from the mysql user in the host machine.
+ENV MYSQL_UID 108
+ENV MYSQL_GID 996
+
+RUN usermod -u $MYSQL_UID mysql; groupmod -g $MYSQL_GID mysql;
+
+RUN chown -R mysql:mysql /var/lib/mysql /var/run/mysqld /var/log/mysql

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Xabi
+Copyright (c) 2021-2022 Club Celica España
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/conf/mariadb-custom.cnf
+++ b/conf/mariadb-custom.cnf
@@ -2,5 +2,5 @@
 log-error = /var/log/mysql/error.log
 log_warnings = 2
 log_output = FILE
-general_log = 1
+general_log = 0
 general_log_file = /var/log/mysql/general.log

--- a/conf/mariadb-custom.cnf
+++ b/conf/mariadb-custom.cnf
@@ -1,6 +1,6 @@
 [mariadb]
 log-error = /var/log/mysql/error.log
-log_warnings = 9
+log_warnings = 2
 log_output = FILE
 general_log = 1
 general_log_file = /var/log/mysql/general.log

--- a/custom/Dockerfile
+++ b/custom/Dockerfile
@@ -2,7 +2,5 @@ FROM alpine:3.15
 
 COPY ./scripts/daily/* /etc/periodic/daily
 
-RUN apk update && \
-  apk upgrade && \
-  apk add --no-cache mariadb-client && \
+RUN apk add --no-cache mariadb-client=10.6.4-r2 && \
   chmod a+x /etc/periodic/daily/*

--- a/custom/scripts/daily/backup-database.sh
+++ b/custom/scripts/daily/backup-database.sh
@@ -10,6 +10,9 @@ MHOST=hostname
 MPASS=password
 MUSER=username
 
+# Clean old files before generating a new one
+find ${BACKUP_FOLDER} -mindepth 1 -mtime +7 -delete
+
 [ ! -d "$BACKUP_FOLDER" ] && mkdir --parents $BACKUP_FOLDER
 FILE=${BACKUP_FOLDER}/backup-mariadb_${NOW}.sql.gz
 $MYSQLDUMP -h $MHOST -u $MUSER -p${MPASS} --databases $MDB | $GZIP -9 > $FILE

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,10 @@ version: "3.7"
 
 services:
   mariadb:
-    image: mariadb:10.4.22
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: mariadb:latest
     container_name: mariadb
     restart: always
     networks:


### PR DESCRIPTION
Contiene lo siguientes cambios:

1. Ayuda a solventar el problema de que los logs no pudiesen ser escritos si se cambiaban los permisos a 640.
2. Aplica mejoras en el Dockerfile de la copia de seguridad.