### PR TITLE
Incluir todas las versiones menores

### DIFF
--- a/custom/Dockerfile
+++ b/custom/Dockerfile
@@ -2,5 +2,5 @@ FROM alpine:3.15
 
 COPY ./scripts/daily/* /etc/periodic/daily
 
-RUN apk add --no-cache mariadb-client=10.6.4-r2 && \
+RUN apk add --no-cache mariadb-client=~10.6.4-r2 && \
   chmod a+x /etc/periodic/daily/*


### PR DESCRIPTION
En vez de elegir una versión específica, se utilizará cualquier versión menor dentro del rango de versiones 10.6.x.