### PR TITLE
Aumentar capacidad de conexiones simultáneas

### DIFF
--- a/conf/mariadb-custom.cnf
+++ b/conf/mariadb-custom.cnf
@@ -1,4 +1,5 @@
 [mariadb]
+max_connections = 201
 log-error = /var/log/mysql/error.log
 log_warnings = 2
 log_output = FILE


### PR DESCRIPTION
Para evitar problemas de conexión cuando hay muchos usuarios conectados, se aumenta el límite actual.

Fixes #3 